### PR TITLE
Allow any node.js >= 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {},
   "engines": {
-    "node": "^10",
+    "node": ">=10",
     "parcel": "^2.0.0-alpha"
   }
 }


### PR DESCRIPTION
Currently, it's impossible to install this when using Node v12 for example